### PR TITLE
Fixed feed reload issue

### DIFF
--- a/bootcamp/feeds/views.py
+++ b/bootcamp/feeds/views.py
@@ -1,5 +1,7 @@
 import json
-
+import sys
+reload(sys)
+sys.setdefaultencoding("utf-8")
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.http import (HttpResponse, HttpResponseBadRequest,


### PR DESCRIPTION
Testing on Ubuntu 16.04, line 59 gave the following error when feed/post queried:
```
Internal Server Error: /feeds/post/
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/exception.py", line 39, in inner
    response = get_response(request)
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/django/contrib/auth/decorators.py", line 23, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "/home/ubuntu/babanpenn/bootcamp/bootcamp/decorators.py", line 9, in wrap
    return f(request, *args, **kwargs)
  File "/home/ubuntu/babanpenn/bootcamp/bootcamp/feeds/views.py", line 120, in post
    html = _html_feeds(last_feed, user, csrf_token)
  File "/home/ubuntu/babanpenn/bootcamp/bootcamp/feeds/views.py", line 79, in _html_feeds
    'csrf_token': csrf_token
UnicodeEncodeError: 'ascii' codec can't encode character u'\xa0' in position 414: ordinal not in range(128)
```

Fixed decode issue by setting the default encoding to utf8 at the top of the file