### PR TITLE
Fix track_comments view.

### DIFF
--- a/bootcamp/feeds/static/js/feeds.js
+++ b/bootcamp/feeds/static/js/feeds.js
@@ -259,9 +259,11 @@ $(function () {
         data: {'feed': feed},
         cache: false,
         success: function (data) {
-          $("ol", container).html(data);
-          var post_container = $(container).closest(".post");
-          $(".comment-count", post_container).text($("ol li", container).length);
+          if (data != 0) {
+            $("ol", container).html(data);
+            var post_container = $(container).closest(".post");
+            $(".comment-count", post_container).text($("ol li", container).length);
+          }
         }
       });
     });

--- a/bootcamp/feeds/views.py
+++ b/bootcamp/feeds/views.py
@@ -187,7 +187,10 @@ def update(request):
 def track_comments(request):
     feed_id = request.GET.get('feed')
     feed = Feed.objects.get(pk=feed_id)
-    return render(request, 'feeds/partial_feed_comments.html', {'feed': feed})
+    if len(feed.get_comments()) > 0:
+        return render(request, 'feeds/partial_feed_comments.html', {'feed': feed})
+    else:
+        return HttpResponse()
 
 
 @login_required


### PR DESCRIPTION
`feeds.views.track_comments` will cause an unexpected comments-count update, see in Issues [#113](https://github.com/vitorfs/bootcamp/issues/113).

To solve this, server better judge if feed has any comments before response to client, because client is not easy to judge if the response is a hint or user's comment (regular expression may not good idea). So when a feed doesn't has comment, server will return 0 and client will not overwrite document.

I'm new to web development, @sebastian-code any good suggestions?