### PR TITLE
Updated "MAILGUN_DOMAIN" to "MAILGUN_SENDER_DOMAIN"

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -128,7 +128,7 @@ EMAIL_BACKEND = 'anymail.backends.mailgun.EmailBackend'
 # https://anymail.readthedocs.io/en/stable/installation/#anymail-settings-reference
 ANYMAIL = {
     'MAILGUN_API_KEY': env('MAILGUN_API_KEY'),
-    'MAILGUN_SENDER_DOMAIN': env('MAILGUN_DOMAIN')
+    'MAILGUN_SENDER_DOMAIN': env('MAILGUN_SENDER_DOMAIN')
 }
 
 # Gunicorn

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,6 +5,7 @@
 boto3>=1.6.2  # pyup: update minor  # https://github.com/boto/boto3
 gevent>=1.2.2  # https://github.com/gevent/gevent
 raven>=6.6.0  # https://github.com/getsentry/raven-python
+gunicorn>=19.9.0    #https://github.com/benoitc/gunicorn
 
 # Django
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
In production, django docker image crashes with the error "MAILGUN_DOMAIN environment variable missing" and so this fixes that issue. 